### PR TITLE
Fix for not being able to send `None` to optional params

### DIFF
--- a/api.py
+++ b/api.py
@@ -147,10 +147,10 @@ def clustering(
     k: int = Form(..., description=k_doc),
     column_drop_threshold: float = Form(0.99, description=column_drop_threshold_doc),
     file_name: str = Form("cluster_model", description=file_name_doc),
-    drop_columns: Optional[List[str]] | None = Form(None, description=drop_columns_doc),
-    categorical_columns: Optional[List[str]] | None = Form(None, description=categorical_columns_doc),
-    numerical_columns: Optional[List[str]] | None = Form(None, description=numerical_columns_doc),
-    ignore_features: Optional[List[str]] | None = Form(None, description=ignore_features_doc),
+    drop_columns: Optional[List[str] | None] = Form(None, description=drop_columns_doc),
+    categorical_columns: Optional[List[str] | None] | = Form(None, description=categorical_columns_doc),
+    numerical_columns: Optional[List[str] | None] | = Form(None, description=numerical_columns_doc),
+    ignore_features: Optional[List[str] | None] | = Form(None, description=ignore_features_doc),
     output_format: str = Form("csv", description=output_format_doc),
 ):
 
@@ -194,10 +194,10 @@ def auto_clustering(
     path_to_csv: UploadFile = File(..., description=path_to_csv_doc),
     column_drop_threshold: float = Form(0.99, description=column_drop_threshold_doc),
     file_name: str = Form("cluster_model", description=file_name_doc),
-    drop_columns: Optional[List[str]] | None = Form(None, description=drop_columns_doc),
-    categorical_columns: Optional[List[str]] | None = Form(None, description=categorical_columns_doc),
-    numerical_columns: Optional[List[str]] | None = Form(None, description=numerical_columns_doc),
-    ignore_features: Optional[List[str]] | None = Form(None, description=ignore_features_doc),
+    drop_columns: Optional[List[str] | None] | = Form(None, description=drop_columns_doc),
+    categorical_columns: Optional[List[str] | None] | = Form(None, description=categorical_columns_doc),
+    numerical_columns: Optional[List[str] | None] | = Form(None, description=numerical_columns_doc),
+    ignore_features: Optional[List[str] | None] | = Form(None, description=ignore_features_doc),
     output_format: str = Form("csv", description=output_format_doc),
 ):
 

--- a/api.py
+++ b/api.py
@@ -147,10 +147,10 @@ def clustering(
     k: int = Form(..., description=k_doc),
     column_drop_threshold: float = Form(0.99, description=column_drop_threshold_doc),
     file_name: str = Form("cluster_model", description=file_name_doc),
-    drop_columns: Optional[List[str]] = Form(None, description=drop_columns_doc),
-    categorical_columns: Optional[List[str]] = Form(None, description=categorical_columns_doc),
-    numerical_columns: Optional[List[str]] = Form(None, description=numerical_columns_doc),
-    ignore_features: Optional[List[str]] = Form(None, description=ignore_features_doc),
+    drop_columns: Optional[List[str]] | None = Form(None, description=drop_columns_doc),
+    categorical_columns: Optional[List[str]] | None = Form(None, description=categorical_columns_doc),
+    numerical_columns: Optional[List[str]] | None = Form(None, description=numerical_columns_doc),
+    ignore_features: Optional[List[str]] | None = Form(None, description=ignore_features_doc),
     output_format: str = Form("csv", description=output_format_doc),
 ):
 
@@ -194,10 +194,10 @@ def auto_clustering(
     path_to_csv: UploadFile = File(..., description=path_to_csv_doc),
     column_drop_threshold: float = Form(0.99, description=column_drop_threshold_doc),
     file_name: str = Form("cluster_model", description=file_name_doc),
-    drop_columns: Optional[List[str]] = Form(None, description=drop_columns_doc),
-    categorical_columns: Optional[List[str]] = Form(None, description=categorical_columns_doc),
-    numerical_columns: Optional[List[str]] = Form(None, description=numerical_columns_doc),
-    ignore_features: Optional[List[str]] = Form(None, description=ignore_features_doc),
+    drop_columns: Optional[List[str]] | None = Form(None, description=drop_columns_doc),
+    categorical_columns: Optional[List[str]] | None = Form(None, description=categorical_columns_doc),
+    numerical_columns: Optional[List[str]] | None = Form(None, description=numerical_columns_doc),
+    ignore_features: Optional[List[str]] | None = Form(None, description=ignore_features_doc),
     output_format: str = Form("csv", description=output_format_doc),
 ):
 

--- a/api.py
+++ b/api.py
@@ -1,5 +1,5 @@
 import shutil
-from typing import List, Optional
+from typing import List, Optional, Union
 import pandas as pd
 from fastapi import FastAPI, File, Query, UploadFile, Form, BackgroundTasks, Body
 from fastapi.responses import FileResponse, PlainTextResponse

--- a/api.py
+++ b/api.py
@@ -148,9 +148,9 @@ def clustering(
     column_drop_threshold: float = Form(0.99, description=column_drop_threshold_doc),
     file_name: str = Form("cluster_model", description=file_name_doc),
     drop_columns: Optional[List[str] | None] = Form(None, description=drop_columns_doc),
-    categorical_columns: Optional[List[str] | None] | = Form(None, description=categorical_columns_doc),
-    numerical_columns: Optional[List[str] | None] | = Form(None, description=numerical_columns_doc),
-    ignore_features: Optional[List[str] | None] | = Form(None, description=ignore_features_doc),
+    categorical_columns: Optional[List[str] | None] = Form(None, description=categorical_columns_doc),
+    numerical_columns: Optional[List[str] | None] = Form(None, description=numerical_columns_doc),
+    ignore_features: Optional[List[str] | None] = Form(None, description=ignore_features_doc),
     output_format: str = Form("csv", description=output_format_doc),
 ):
 
@@ -194,10 +194,10 @@ def auto_clustering(
     path_to_csv: UploadFile = File(..., description=path_to_csv_doc),
     column_drop_threshold: float = Form(0.99, description=column_drop_threshold_doc),
     file_name: str = Form("cluster_model", description=file_name_doc),
-    drop_columns: Optional[List[str] | None] | = Form(None, description=drop_columns_doc),
-    categorical_columns: Optional[List[str] | None] | = Form(None, description=categorical_columns_doc),
-    numerical_columns: Optional[List[str] | None] | = Form(None, description=numerical_columns_doc),
-    ignore_features: Optional[List[str] | None] | = Form(None, description=ignore_features_doc),
+    drop_columns: Optional[List[str] | None] = Form(None, description=drop_columns_doc),
+    categorical_columns: Optional[List[str] | None] = Form(None, description=categorical_columns_doc),
+    numerical_columns: Optional[List[str] | None] = Form(None, description=numerical_columns_doc),
+    ignore_features: Optional[List[str] | None] = Form(None, description=ignore_features_doc),
     output_format: str = Form("csv", description=output_format_doc),
 ):
 

--- a/api.py
+++ b/api.py
@@ -147,10 +147,10 @@ def clustering(
     k: int = Form(..., description=k_doc),
     column_drop_threshold: float = Form(0.99, description=column_drop_threshold_doc),
     file_name: str = Form("cluster_model", description=file_name_doc),
-    drop_columns: Optional[List[str] | None] = Form(None, description=drop_columns_doc),
-    categorical_columns: Optional[List[str] | None] = Form(None, description=categorical_columns_doc),
-    numerical_columns: Optional[List[str] | None] = Form(None, description=numerical_columns_doc),
-    ignore_features: Optional[List[str] | None] = Form(None, description=ignore_features_doc),
+    drop_columns: Union[List[str], None] = Form(None, description=drop_columns_doc),
+    categorical_columns: Union[List[str], None] = Form(None, description=categorical_columns_doc),
+    numerical_columns: Union[List[str], None] = Form(None, description=numerical_columns_doc),
+    ignore_features: Union[List[str], None] = Form(None, description=ignore_features_doc),
     output_format: str = Form("csv", description=output_format_doc),
 ):
 
@@ -194,10 +194,10 @@ def auto_clustering(
     path_to_csv: UploadFile = File(..., description=path_to_csv_doc),
     column_drop_threshold: float = Form(0.99, description=column_drop_threshold_doc),
     file_name: str = Form("cluster_model", description=file_name_doc),
-    drop_columns: Optional[List[str] | None] = Form(None, description=drop_columns_doc),
-    categorical_columns: Optional[List[str] | None] = Form(None, description=categorical_columns_doc),
-    numerical_columns: Optional[List[str] | None] = Form(None, description=numerical_columns_doc),
-    ignore_features: Optional[List[str] | None] = Form(None, description=ignore_features_doc),
+    drop_columns: Union[List[str], None] = Form(None, description=drop_columns_doc),
+    categorical_columns: Union[List[str], None] = Form(None, description=categorical_columns_doc),
+    numerical_columns: Union[List[str], None] = Form(None, description=numerical_columns_doc),
+    ignore_features: Union[List[str], None] = Form(None, description=ignore_features_doc),
     output_format: str = Form("csv", description=output_format_doc),
 ):
 

--- a/pydacc/data_cleaning.py
+++ b/pydacc/data_cleaning.py
@@ -82,6 +82,7 @@ def clean_data(
 def get_common_items(list1, list2):
     """
     Compares two lists and returns the common items in a new list. Used internally.
+    If one of the lists is `None` it will return `None` instead of trying to iterate through eeach. This prevents the `TypeError: argument of type 'NoneType' is not iterable` error.
 
     Example
     -------
@@ -95,5 +96,8 @@ def get_common_items(list1, list2):
 
     returns: list
     """
-    common = [value for value in list1 if value in list2]
-    return common
+    if list1 or list2 is None:
+        return None
+    else:
+        common = [value for value in list1 if value in list2]
+        return common

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-fastapi==0.70.0
+fastapi==0.81.0
 klib==1.0.1
 pandas==1.2.5
 pycaret==2.3.5

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ klib==1.0.1
 pandas==1.2.5
 pycaret==2.3.5
 requests==2.26.0
-starlette==0.16.0
+starlette==0.19.1
 uvicorn[standard]==0.15.0
 gunicorn==20.1.0
 python-multipart==0.0.5


### PR DESCRIPTION
- The problem was: `TypeError: argument of type 'NoneType' is not iterable`

- Turns out it wasn't a problem with `api.py` but in `pydacc/clean_data.py`
- `get_common_items()` crashed when one of its arguments was `None` which happened when an optional param, specifically `categorical_columns` and `numerical_columns`, was empty in the request
- `get_common_items()` now returns `None` if one of its input arguments (lists) are `None`
- Updated FastAPI and Starlette